### PR TITLE
CGKIELE-570: Updating web3 to fix a load-balancer problem.

### DIFF
--- a/src/components/pages/Main.js
+++ b/src/components/pages/Main.js
@@ -26,9 +26,11 @@ class Main extends Component {
 
   async loadTransactions(eth, block) {
     const transactions = [];
-    for (let i = 0; i < block.transactions.length; i++) {
-      const tx = await promisify(eth.getTransaction)(block.transactions[i]);
-      transactions.unshift(tx);
+    if (block && block.transactions) {
+      for (let i = 0; i < block.transactions.length; i++) {
+        const tx = await promisify(eth.getTransaction)(block.transactions[i]);
+        transactions.unshift(tx);
+      }
     }
     return transactions;
   }
@@ -42,12 +44,14 @@ class Main extends Component {
       const fromBlock = Math.max(latestBlockNumber - MAX_HISTORY, latestBlockKnown + 1);
       for (let i = fromBlock; i <= latestBlockNumber; i++) {
         const block = await promisify(eth.getBlock)(i);
-        const txs = await this.loadTransactions(eth, block);
-        this.state.latestBlocks.unshift(block);
-        this.setState({
-          latestBlocks: this.state.latestBlocks.splice(0, MAX_HISTORY),
-          latestTxs: txs.concat(this.state.latestTxs).splice(0, MAX_HISTORY)
-        });
+        if (block) {
+          const txs = await this.loadTransactions(eth, block);
+          this.state.latestBlocks.unshift(block);
+          this.setState({
+            latestBlocks: this.state.latestBlocks.splice(0, MAX_HISTORY),
+            latestTxs: txs.concat(this.state.latestTxs).splice(0, MAX_HISTORY)
+          });
+        };
       }
       this.loading = false;
     }

--- a/src/utils/web3-loader.js
+++ b/src/utils/web3-loader.js
@@ -2,7 +2,7 @@ import Web3 from 'web3'
 
 const USE_INJECTED_WEB3 = false;
 
-const FALLBACK_PROVIDER = window.location.protocol + "//" + window.location.hostname + ':8546';
+const FALLBACK_PROVIDER = '/api/';
 
 let getWeb3 = new Promise(function(resolve, reject) {
   // Wait for loading completion to avoid race conditions with web3 injection timing.


### PR DESCRIPTION
Web3 v0.19.x didn't handle cookies correctly, which mean AWS couldn't
implement load balancing with sticky sessions:

  https://github.com/ethereum/web3.js/issues/1665

This updates us to 0.20.x.